### PR TITLE
PDTVT-3070 fix some compilation errors

### DIFF
--- a/lib/headers/strict_transport_security.ex
+++ b/lib/headers/strict_transport_security.ex
@@ -64,8 +64,8 @@ defmodule SecureHeaders.StrictTrasportSecurity do
 
   defp make_string(sts_config) do
     max_age = append_max_age(sts_config[:max_age])
-    if max_age && Regex.match?(~r/^max-age=\d+$/,max_age) do 
-      result = append_max_age(max_age)
+    result = if max_age && Regex.match?(~r/^max-age=\d+$/,max_age) do 
+      append_max_age(max_age)
     end
     if Keyword.get(sts_config, :includesubdomains), do: result = result <> "; includeSubdomains"
     if Keyword.get(sts_config, :preload), do: result = result <> "; preload"

--- a/lib/secure_headers.ex
+++ b/lib/secure_headers.ex
@@ -25,7 +25,6 @@ defmodule SecureHeaders do
       options
       |> SecureHeaders.SecureHeaders.validate
       |> SecureHeaders.ContentSecurityPolicy.validate
-      |> SecureHeaders.HttpPublicKeyPins.validate
       |> SecureHeaders.StrictTrasportSecurity.validate
       |> SecureHeaders.XContentTypeOptions.validate
       |> SecureHeaders.XDownloadOptions.validate


### PR DESCRIPTION
https://diligentbrands.atlassian.net/browse/PDTVT-3082

This fixes a couple of compilation errors/warnings with Elixir 13:

- After bumping the Elixir version, the compiler complained that result was an undeclared variable. From Googling assigning it inside a if/else block will cause the variable to be out of scope, and a recommended solution was to assign the variable from the result of the if/else statement: https://stackoverflow.com/questions/39550644/elixir-set-variable-in-if-statement

- SecureHeaders.HttpPublicKeyPins.validate was removed because the compiler was complaining that HttpPublicKeyPins was an undeclared module, and there doesn't seem to be a module named this.